### PR TITLE
FDM authentication token retrieval

### DIFF
--- a/fdm_api_util.py
+++ b/fdm_api_util.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+"""Authenticate with FDM and obtain an API access token."""
+
+#import sys
+#from pathlib import Path
+
+import requests
+from requests import HTTPError
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+
+from hosts import FDM
+
+
+# Disable insecure request warnings
+requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+
+
+def fdm_login(
+    host=FDM.get("host"),
+    port=FDM.get("port"),
+    username=FDM.get("username"),
+    password=FDM.get("password"),
+):
+    """Login to FDM and return an access token that may be used for API calls.
+    
+    This login will give you an access token that is valid for ~30 minutes
+    with no refresh. Using this token should be fine for short running scripts.
+    """
+
+    url = f"https://{host}:{port}/api/fdm/latest/fdm/token"
+
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+    payload = {
+        "grant_type": "password",
+        "username": username,
+        "password": password,
+    }
+
+    response = requests.post(
+        url,
+        headers=headers,
+        json=payload,
+        verify=False,
+    )
+
+    try:
+        response.raise_for_status()
+        access_token = response.json()["access_token"]
+
+    except HTTPError:
+        if response.status_code == 400:
+            raise HTTPError(f"Error logging in to FDM: {response.text}")
+        else:
+            raise
+
+    except ValueError:
+        raise ValueError("Error parsing the response from FDM")
+
+    return access_token
+
+if __name__ == "__main__":
+    token = fdm_login()
+    if token:
+        print("Login was successful!")
+        print(f"Access Token: {token}")

--- a/fdm_api_util.py
+++ b/fdm_api_util.py
@@ -1,12 +1,9 @@
 #!/usr/bin/env python
-"""Authenticate with FDM and obtain an API access token."""
-
-#import sys
-#from pathlib import Path
 
 import requests
 from requests import HTTPError
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
+from pprint import pformat
 
 from hosts import FDM
 
@@ -62,8 +59,40 @@ def fdm_login(
 
     return access_token
 
+
+def fdm_get_networks(
+    access_token,
+    host=FDM.get("host"),
+    port=FDM.get("port")
+):
+    """Get the list of all Networks in FDM."""
+
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "Authorization": f"Bearer {access_token}",
+    }
+
+    response = requests.get(
+        f"https://{host}:{port}/api/fdm/latest/object/networks",
+        headers=headers,
+        verify=False,
+    )
+    response.raise_for_status()
+
+    return response.json()
+
+
 if __name__ == "__main__":
     token = fdm_login()
     if token:
         print("Login was successful!")
-        print(f"Access Token: {token}")
+        print(f"Access Token: {token}\n")
+
+    networks = fdm_get_networks(token)
+
+    print(
+        'Network(s):',
+        pformat(networks),
+        sep="\n",
+    )

--- a/hosts.py
+++ b/hosts.py
@@ -1,0 +1,8 @@
+# Add your environment variables
+
+FDM = {
+    "host": "", #ip
+    "port": 443,
+    "username": "admin",
+    "password": "",
+}


### PR DESCRIPTION
Adding a utility function (fdm_login) to get auth token from FTD via REST API.

The host variables are stored in hosts.py. - I worked on the test lab, and I didn't include the ip address and the password here. I saw that you have a config file too for this, we should merge these.

Also added a function to test the token (fdm_get_networks).

The script runs on python3 and requires the requests and pretty print libraries. We should add a requirements.txt file to make it easier to track these.

The code is basically copy-paste from the related security module: https://github.com/CiscoDevNet/dne-security-code